### PR TITLE
Skeleton of Enzyme Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,21 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
+
+find_package(Enzyme REQUIRED CONFIG)
+
+# Trade off flexibility for correctness: compilation *will* fail if using a non
+# clang compiler, or a different clang/LLVM version than the one used to build
+# Enzyme. Compilers can only be configured before a project() call.
+message("LLVM Version: " ${Enzyme_LLVM_VERSION_MAJOR})
+message("Found LLVM at: " ${Enzyme_LLVM_BINARY_DIR})
+set(CMAKE_C_COMPILER "${Enzyme_LLVM_BINARY_DIR}/bin/clang")
+set(CMAKE_CXX_COMPILER "${Enzyme_LLVM_BINARY_DIR}/bin/clang++")
+
 project(libshell)
 
-set (CMAKE_CXX_STANDARD 11)
-set(MSVC_RUNTIME "dynamic")
+get_property(importTargetsAfter DIRECTORY "${CMAKE_SOURCE_DIR}" PROPERTY IMPORTED_TARGETS)
+message("imported targets ${importTargetsAfter}")
+
+set(CMAKE_CXX_STANDARD 11)
 set(LIBIGL_EIGEN_VERSION 3.3.7 CACHE STRING "Eigen version")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -11,21 +24,16 @@ include(libigl)
 igl_include(glfw)
 igl_include(imgui)
 
-# Add your project files
-if(MSVC)
-	add_definitions(-DEIGEN_STRONG_INLINE=inline)
-endif()
-
 file(GLOB LIBFILES src/*.cpp src/SecondFundamentalForm/*.cpp src/MaterialModel/*.cpp)
 add_library(${PROJECT_NAME} STATIC ${LIBFILES})
-target_link_libraries(${PROJECT_NAME} igl::core)
+target_link_libraries(${PROJECT_NAME} PUBLIC igl::core LLDEnzymeFlags)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_CURRENT_LIST_DIR}/lib)
 
 file(GLOB EXAMPLEFILES example/*.cpp)
 add_executable(example_${PROJECT_NAME} ${EXAMPLEFILES})
-target_link_libraries(example_${PROJECT_NAME} ${PROJECT_NAME} igl::core igl::glfw igl::imgui)
+target_link_libraries(example_${PROJECT_NAME} PUBLIC ${PROJECT_NAME} igl::core igl::glfw igl::imgui LLDEnzymeFlags)
 
 file(GLOB TESTFILES tests/*.cpp)
 add_executable(tests_${PROJECT_NAME} ${TESTFILES})
-target_link_libraries(tests_${PROJECT_NAME} ${PROJECT_NAME} igl::core)
+target_link_libraries(tests_${PROJECT_NAME} PUBLIC ${PROJECT_NAME} igl::core LLDEnzymeFlags)

--- a/src/MeshConnectivity.cpp
+++ b/src/MeshConnectivity.cpp
@@ -3,6 +3,16 @@
 #include <vector>
 #include <map>
 
+
+extern double __enzyme_autodiff(void*, double);
+double square(double x) {
+    return x * x;
+}
+double dsquare(double x) {
+    // This returns the derivative of square or 2 * x
+    return __enzyme_autodiff((void*) square, x);
+}
+
 namespace LibShell {
 
     MeshConnectivity::MeshConnectivity()


### PR DESCRIPTION
This PR demos how to modify the CMakeLists.txt to build with Enzyme. It also includes a very simple example of a function being autodiffed by Enzyme.

I have verified that the `square` and `dsquare` function appear in liblibshell.a when building. This PR is not intended to be merged as-is.